### PR TITLE
Fix exception when trying to read profiles stored in binary format

### DIFF
--- a/FS2020Control/XmlToSqlite.cs
+++ b/FS2020Control/XmlToSqlite.cs
@@ -128,8 +128,10 @@ namespace FS2020Control
         return false;
       if (!IsSteam && path.Length < FS2020ContainerDir.Length + 32)
         return false;
-      string line = File.ReadLines(path).First();
-      return line.StartsWith("<?xml ");
+      var line = new byte[6];
+      using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+        fs.Read(line, 0, 6);
+      return Encoding.Default.GetString(line).StartsWith("<?xml");
     }
 
     public int ImportXmlFiles()


### PR DESCRIPTION
Hi Dieter,

In my MSFS "Store" version "wgs" profiles there are some files that are in a binary format. They "look" like profile files, with the long GUID name, but they're not text or XML.
(Not entirely sure what they are... range from 2 to 870 KB, have `LZMA` header but 7-Zip can't open them.  🤷🏼 )

`File.ReadLines()` returns an empty array for these binary files, leading to an exception when trying to call `.First()` on the result.

Alternatively, replacing `First()` with `FirstOrDefault()` also works, but I figured why bother trying to read the whole file just for the first few bytes anyway.

For me the program would just crash on startup because it (cleverly :) found my profiles folder and started scanning.

Even running it in debugger didn't make it obvious where the problem was... It _looked_ like some issue with the SQLite lib/driver actually, deep in native code after several native <-> managed transfers. Strange.

Incidentally, a similar project ([FSProfiles](https://github.com/iadarroch/FSProfiles)) I tried had the [same issue](https://github.com/iadarroch/FSProfiles/blob/main/FSProfiles.Common/Classes/FolderProcessorBase.cs#L19). Perhaps something changed in MSFS2020 that started creating these binary files. 
Actually fixing that one helped me figure out where yours was crashing. Submitting a PR there next. :)

Also, cool app, thanks for publishing!

Best,
-Max
